### PR TITLE
Update footer styling and colors

### DIFF
--- a/themes/sk2/static/css/sk2.css
+++ b/themes/sk2/static/css/sk2.css
@@ -63,7 +63,8 @@ a:hover {
   h3 { color: #cbd5e0; }
   .navbar a { color: #e2e8f0; }
   .navbar a:hover { color: #cbd5e0; }
-  .footer-content { color: #718096; }
+  .site-footer { background-color: #ff1493; }
+  .footer-content { color: #ffffff; }
 }
 
 .flex {
@@ -234,10 +235,12 @@ h3 {
 .site-footer {
     margin-top: 2rem;
     padding-top: 1rem;
+    background-color: #ff69b4;
+    padding: 1rem;
 }
 
 .footer-content {
     text-align: right;
     font-size: 0.9rem;
-    color: #718096;
+    color: #ffffff;
 }


### PR DESCRIPTION
Adjust footer CSS to improve visibility and match site theme. Change footer background to a pink hue and set footer text color to white for better contrast and readability. Also add padding adjustments to the site-footer for spacing.

- Replace .footer-content text color with white
- Add .site-footer background-color and padding
- Ensure consistent styling by updating duplicate selectors